### PR TITLE
Troubleshoot long socket names and auth

### DIFF
--- a/README.md
+++ b/README.md
@@ -290,7 +290,7 @@ After we provision, the `.engraver/clusters/dev.json` file will have lots of det
 Time to stand up our cluster in the cloud. Run the following command to spin up our 3-node cluster:
 
 ```
-$ engraver cluster provision --cluster-id dev
+$ sudo engraver cluster provision --cluster-id dev
 ```
 
 You'll see a fair amount of Ansible output. If you run into any unexpected problems, you can add `--ansible='-vvvv'` to the end of that line - which will put Ansible into verbose mode. When you provision in AWS, Ansible will:

--- a/src/ansible_template/ansible.cfg
+++ b/src/ansible_template/ansible.cfg
@@ -2,3 +2,6 @@
 filter_plugins = /usr/share/ansible_plugins/filter_plugins:./filter_plugins
 roles_path = roles
 host_key_checking = False
+
+[ssh_connection]
+control_path = %(directory)s/%%h-%%p-%%r


### PR DESCRIPTION
The following seems to fix the problem with the socket names being to long. Add this...

``` [ssh_connection]
 control_path = %(directory)s/%%h-%%p-%%r
```

 to ansible config. There seems to be an issue with long socket names: https://stackoverflow.com/questions/35595468/ansible-connection-to-aws-host-fails-with-unknown-ssh-error

The second step i thought i needed to take was to run provisioning script with sudo, because you my user didnt have the sufficient permissions.  Here is a link to a possible similar issue here: https://www.mail-archive.com/ansible-project@googlegroups.com/msg09336.html 
